### PR TITLE
Move touche functions into a class

### DIFF
--- a/Touche.roboFontExt/lib/Touche.py
+++ b/Touche.roboFontExt/lib/Touche.py
@@ -173,8 +173,8 @@ class Touche(object):
         font = CurrentFont()
         a, b = font['a'], font['b']
         touche = Touche(font)
-        touche.checkPair()
-        touche.findTouchingPairs([font['a'], font['b']])
+        touche.checkPair(a, b)
+        touche.findTouchingPairs([a, b])
     
     Public methods: checkPair, findTouchingPairs
     """


### PR DESCRIPTION
This adds a `Touche` class to the script, which all of the overlapping logic has been moved into. Extracting the functions into a class is a convenient way to group functionality together. I find that this helps the maintainability of the script, because it's possible to start decoupling the class that controls the UI from the other domain logic.

This could go a bit further to make the `checkFont` method leaner, but I didn't want to move a lot of other stuff around at this point.
